### PR TITLE
Use secure Hotline Webring links

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -43,8 +43,8 @@
         <p id="copyright">
           &copy; pbrisbin dot com 2008 - forever.
           <a href="https://github.com/pbrisbin/pbrisbin.com">source</a>.
-          <a href="http://hotlinewebring.club/pbrisbin/next">next</a>.
-          <a href="http://hotlinewebring.club/pbrisbin/previous">previous</a>.
+          <a href="https://hotlinewebring.club/pbrisbin/next">next</a>.
+          <a href="https://hotlinewebring.club/pbrisbin/previous">previous</a>.
         </p>
       </footer>
     </section>


### PR DESCRIPTION
* pbrisbin.com uses HTTPS
* When HTTPS links to HTTP, it doesn't send a Referer header
* Hotline Webring relies on the Referer header to know which site to add to the ring